### PR TITLE
Add team API

### DIFF
--- a/api_team.go
+++ b/api_team.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type TeamsResponse struct {
+	Teams   []Team `json:"teams,omitempty"`
+	Message string `json:"message"`
+	Error   string `json:"error"`
+}
+
+// Fetches every team from the DB and returns them as JSON
+func ListTeams(w http.ResponseWriter, r *http.Request) {
+	var res TeamsResponse
+
+	t, err := c.GetAllTeams()
+	if err != nil {
+		res.Error = err.Error()
+		errjson, _ := json.Marshal(res)
+		http.Error(w, string(errjson), http.StatusInternalServerError)
+		return
+	}
+
+	for _, v := range t {
+		res.Teams = append(res.Teams, *v)
+	}
+
+	json.NewEncoder(w).Encode(res)
+}
+
+// Fetches a single person form the DB and returns them as JSON
+func ShowTeam(w http.ResponseWriter, r *http.Request) {
+	var res TeamsResponse
+
+	vars := mux.Vars(r)
+	name := vars["team"]
+
+	p, err := c.GetTeam(name)
+	if err != nil {
+		res.Error = err.Error()
+		errjson, _ := json.Marshal(res)
+		http.Error(w, string(errjson), http.StatusNotFound)
+		return
+	}
+
+	res.Teams = append(res.Teams, *p)
+
+	json.NewEncoder(w).Encode(res)
+}
+
+// Deletes the specified team from the database
+func DeleteTeam(w http.ResponseWriter, r *http.Request) {
+	var res PeopleResponse
+
+	vars := mux.Vars(r)
+	name := vars["team"]
+
+	err := c.DeleteTeam(name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	res.Message = fmt.Sprint("Team ", name, " deleted")
+
+	json.NewEncoder(w).Encode(res)
+}
+
+// Creates a new person in the database
+func CreateTeam(w http.ResponseWriter, r *http.Request) {
+	var res TeamsResponse
+	var t Team
+
+	// We're getting the details of this new team from the POSTed JSON
+	// so we first need to read in the body of the POST
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1024*10))
+	// If something went wrong, return an error in the JSON response
+	if err != nil {
+		res.Error = err.Error()
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+
+	err = r.Body.Close()
+	if err != nil {
+		res.Error = err.Error()
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+
+	// Attempt to unmarshall the JSON into our Person struct
+	err = json.Unmarshal(body, &t)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(422) // unprocessable entity
+		res.Error = err.Error()
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+
+	// If a name was not provided, return an error
+	if t.Name == "" {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(422) // unprocessable entity
+		res.Error = "Must provide username and fullname"
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+
+	// Make sure that this team doesn't already exist
+	fp, err := c.GetTeam(t.Name)
+	if fp != nil && fp.Name != "" {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(422) // unprocessable entity
+		res.Error = fmt.Sprint("Team ", t.Name, " already exists. Use PUT /teams/", t.Name, "/ to update.")
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+	if err != nil {
+		log.Println("GetTeam() failed:", err)
+	}
+
+	// Store our new team in the DB
+	err = c.StoreTeam(&t)
+	if err != nil {
+		log.Println("Error storing person:", err)
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(422) // unprocessable entity
+		res.Error = err.Error()
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+
+	res.Message = fmt.Sprint("Team ", t.Name, " created")
+
+	json.NewEncoder(w).Encode(res)
+}
+
+// Updates an existing person in the database
+func UpdateTeam(w http.ResponseWriter, r *http.Request) {
+	var res TeamsResponse
+	var t Team
+
+	vars := mux.Vars(r)
+	name := vars["team"]
+
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1024*10))
+	// If something went wrong, return an error in the JSON response
+	if err != nil {
+		res.Error = err.Error()
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+
+	err = r.Body.Close()
+	if err != nil {
+		res.Error = err.Error()
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+
+	err = json.Unmarshal(body, &t)
+
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(422) // unprocessable entity
+		res.Error = err.Error()
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+
+	// Make sure the user actually exists before updating
+	fp, err := c.GetTeam(name)
+	if fp != nil && fp.Name == "" {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(422) // unprocessable entity
+		res.Error = fmt.Sprint("Team ", t.Name, " does not exist. Use POST to create.")
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+	if err != nil {
+		log.Println("GetTeam() failed for", name)
+	}
+
+	// Now that we know our team exists in the DB, copy the username from the URI path and add it to our struct
+	t.Name = name
+
+	// Store the updated user in the DB
+	err = c.StoreTeam(&t)
+	if err != nil {
+		log.Println("Error storing team", err)
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.WriteHeader(422) // unprocessable entity
+		res.Error = err.Error()
+		json.NewEncoder(w).Encode(res)
+		return
+	}
+
+	res.Teams = append(res.Teams, t)
+	res.Message = fmt.Sprint("Team ", name, " updated")
+
+	json.NewEncoder(w).Encode(res)
+
+}

--- a/api_team.go
+++ b/api_team.go
@@ -36,7 +36,7 @@ func ListTeams(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(res)
 }
 
-// Fetches a single person form the DB and returns them as JSON
+// Fetches a single team from the DB and returns them as JSON
 func ShowTeam(w http.ResponseWriter, r *http.Request) {
 	var res TeamsResponse
 
@@ -74,7 +74,7 @@ func DeleteTeam(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(res)
 }
 
-// Creates a new person in the database
+// Creates a new team in the database
 func CreateTeam(w http.ResponseWriter, r *http.Request) {
 	var res TeamsResponse
 	var t Team
@@ -96,7 +96,7 @@ func CreateTeam(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Attempt to unmarshall the JSON into our Person struct
+	// Attempt to unmarshall the JSON into our Team struct
 	err = json.Unmarshal(body, &t)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
@@ -110,7 +110,7 @@ func CreateTeam(w http.ResponseWriter, r *http.Request) {
 	if t.Name == "" {
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		w.WriteHeader(422) // unprocessable entity
-		res.Error = "Must provide username and fullname"
+		res.Error = "Must provide a team name"
 		json.NewEncoder(w).Encode(res)
 		return
 	}
@@ -131,7 +131,7 @@ func CreateTeam(w http.ResponseWriter, r *http.Request) {
 	// Store our new team in the DB
 	err = c.StoreTeam(&t)
 	if err != nil {
-		log.Println("Error storing person:", err)
+		log.Println("Error storing team:", err)
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		w.WriteHeader(422) // unprocessable entity
 		res.Error = err.Error()
@@ -144,7 +144,7 @@ func CreateTeam(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(res)
 }
 
-// Updates an existing person in the database
+// Updates an existing team in the database
 func UpdateTeam(w http.ResponseWriter, r *http.Request) {
 	var res TeamsResponse
 	var t Team
@@ -177,7 +177,7 @@ func UpdateTeam(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Make sure the user actually exists before updating
+	// Make sure the team actually exists before updating
 	fp, err := c.GetTeam(name)
 	if fp != nil && fp.Name == "" {
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
@@ -190,10 +190,10 @@ func UpdateTeam(w http.ResponseWriter, r *http.Request) {
 		log.Println("GetTeam() failed for", name)
 	}
 
-	// Now that we know our team exists in the DB, copy the username from the URI path and add it to our struct
+	// Now that we know our team exists in the DB, copy the name from the URI path and add it to our struct
 	t.Name = name
 
-	// Store the updated user in the DB
+	// Store the updated team in the DB
 	err = c.StoreTeam(&t)
 	if err != nil {
 		log.Println("Error storing team", err)

--- a/chickenlittle.go
+++ b/chickenlittle.go
@@ -83,6 +83,21 @@ func main() {
 	apiRouter.HandleFunc("/notifications/{uuid}", StopNotification).
 		Methods("DELETE")
 
+	apiRouter.HandleFunc("/teams", ListTeams).
+		Methods("GET")
+
+	apiRouter.HandleFunc("/teams", CreateTeam).
+		Methods("POST")
+
+	apiRouter.HandleFunc("/teams/{team}", ShowTeam).
+		Methods("GET")
+
+	apiRouter.HandleFunc("/teams/{team}", DeleteTeam).
+		Methods("DELETE")
+
+	apiRouter.HandleFunc("/teams/{team}", UpdateTeam).
+		Methods("PUT")
+
 	go func() {
 		log.Fatal(http.ListenAndServe(c.Config.Service.APIListenAddr, apiRouter))
 	}()

--- a/docs/TEAM_API.md
+++ b/docs/TEAM_API.md
@@ -1,0 +1,161 @@
+# Team API
+
+## Get list of all teams
+**Request**
+```
+GET /teams
+```
+
+**Example Response**
+```
+HTTP/1.1 200 OK
+```
+```json
+{
+  "teams": [
+    {
+      "description": "Kings", 
+      "members": [
+        "arthur"
+      ], 
+      "name": "kings", 
+      "rotation": {
+        "description": "none", 
+        "frequency": 0, 
+        "time": "0001-01-01T00:00:00Z"
+      }, 
+      "steps": [
+        {
+          "method": 0, 
+          "target": "", 
+          "timebefore": 3600
+        }
+      ]
+    }
+  ],
+  "message": "",
+  "error": ""
+}
+```
+
+## Fetch details for a team
+**Request**
+```
+GET /teams/NAME
+```
+
+**Example Response**
+```
+HTTP/1.1 200 OK
+```
+```json
+{
+  "teams": [
+    {
+      "description": "Kings", 
+      "members": [
+        "arthur"
+      ], 
+      "name": "kings", 
+      "rotation": {
+        "description": "none", 
+        "frequency": 0, 
+        "time": "0001-01-01T00:00:00Z"
+      }, 
+      "steps": [
+        {
+          "method": 0, 
+          "target": "", 
+          "timebefore": 3600
+        }
+      ]
+    }
+  ],
+  "message": "",
+  "error": ""
+}
+```
+
+## Create a new team
+**Request**
+```
+POST /teams
+
+{
+  "description": "Kings", 
+  "members": [
+    "arthur"
+  ], 
+  "name": "kings", 
+  "rotation": {
+    "description": "none", 
+    "frequenc": 0, 
+    "time": 0
+  }, 
+  "steps": {
+    "method": 0, 
+    "target": "", 
+    "timebefore": 3600
+  }
+}
+```
+
+**Example Response**
+```
+HTTP/1.1 200 OK
+```
+```json
+{
+  "message": "Team kings created",
+  "error": ""
+}
+```
+
+## Update a team
+**Request**
+```
+PUT /teams/NAME
+
+{
+  "description": "Kings and Queens",
+  "members": [
+    "arthur",
+    "lancelot"
+  ]
+}
+```
+
+**Example Response**
+```
+HTTP/1.1 200 OK
+```
+```json
+{
+  "teams": [
+    {
+      "name": "kings",
+      "description": "Kings and Queens"
+    }
+  ],
+  "message": "Team kings updated",
+  "error": ""
+}
+```
+
+## Delete a team
+**Request**
+```
+DELETE /teams/NAME
+```
+
+**Example Response**
+```
+HTTP/1.1 200 OK
+```
+```json
+{
+  "message": "Team kings deleted",
+  "error": ""
+}
+```
+

--- a/escalation.go
+++ b/escalation.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type EscalationMethod int
+
+const (
+	NotifyOnDuty         EscalationMethod = iota // 0
+	NotifyNextInRotation                         // 1
+	NotifyOtherPerson                            // 2
+	NotifyWebhook                                // 3
+	NotifyEmail                                  // 4
+)
+
+// EscalationStep defines how alerts are escalated when an contact
+// does not respond in time. Target takes a different meaning depending on
+// the EscalationMethod. It is ignored on NotifyOnDuty or NotifyNextInRotation.
+// For NotifyOtherPerson it's the name of another contact, for CallWebhook it's an URL
+// and for SendEmail it's an email address.
+type EscalationStep struct {
+	TimeBeforeEscalation time.Duration    `yaml:"timebefore" json:"timebefore"` // How long to try the current step
+	Method               EscalationMethod `yaml:"method" json:"method"`         // What action to take during this step
+	Target               string           `yaml:"target" json:"target"`         // Who or what to do the action with
+}
+
+func (e *EscalationMethod) Marshal() ([]byte, error) {
+	je, err := json.Marshal(&e)
+	return je, err
+}
+
+func (e *EscalationMethod) Unmarshal(je string) error {
+	err := json.Unmarshal([]byte(je), &e)
+	return err
+}
+
+func (e *EscalationStep) Marshal() ([]byte, error) {
+	je, err := json.Marshal(&e)
+	return je, err
+}
+
+func (e *EscalationStep) Unmarshal(je string) error {
+	err := json.Unmarshal([]byte(je), &e)
+	return err
+}

--- a/rotation.go
+++ b/rotation.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// RotationPolicy defines how shifts are rotated. If the frequency is zero
+// no automatic rotations should be attempted.
+type RotationPolicy struct {
+	Description       string        `yaml:"description" json:"description"`
+	RotationFrequency time.Duration `yaml:"frequency" json:"frequency"`
+	RotateTime        time.Time     `yaml:"time" json:"time"`
+}
+
+func (r *RotationPolicy) Marshal() ([]byte, error) {
+	jr, err := json.Marshal(&r)
+	return jr, err
+}
+
+func (r *RotationPolicy) Unmarshal(jr string) error {
+	err := json.Unmarshal([]byte(jr), &r)
+	return err
+}

--- a/team.go
+++ b/team.go
@@ -6,9 +6,11 @@ import (
 )
 
 type Team struct {
-	Name        string   `yaml:"name" json:"name"`
-	Description string   `yaml:"description" json:"description"`
-	Members     []string `yaml:"members" json:"members"`
+	Name            string           `yaml:"name" json:"name"`
+	Description     string           `yaml:"description" json:"description"`
+	Members         []string         `yaml:"members" json:"members"`
+	Rotation        RotationPolicy   `yaml:"rotation" json:"rotation"`
+	EscalationSteps []EscalationStep `yaml:"steps" json:"steps"`
 }
 
 func (t *Team) Marshal() ([]byte, error) {

--- a/team.go
+++ b/team.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Team struct {
+	Name        string   `yaml:"name" json:"name"`
+	Description string   `yaml:"description" json:"description"`
+	Members     []string `yaml:"members" json:"members"`
+}
+
+func (t *Team) Marshal() ([]byte, error) {
+	jt, err := json.Marshal(&t)
+	return jt, err
+}
+
+func (t *Team) Unmarshal(jt string) error {
+	err := json.Unmarshal([]byte(jt), &t)
+	return err
+}
+
+// Fetch a Team from the DB
+func (c *ChickenLittle) GetTeam(t string) (*Team, error) {
+	jt, err := c.DB.Fetch("teams", t)
+	if err != nil {
+		return nil, fmt.Errorf("Could not fetch team %v from DB", t)
+	}
+
+	team := &Team{}
+
+	err = team.Unmarshal(jt)
+	if err != nil {
+		return nil, fmt.Errorf("Could not unmarshal team from DB.  Err: %v  JSON: %v", err, jt)
+	}
+
+	return team, nil
+}
+
+// Fetch every Team from the DB
+func (c *ChickenLittle) GetAllTeams() ([]*Team, error) {
+	var teams []*Team
+
+	jt, err := c.DB.FetchAll("teams")
+	if err != nil {
+		return nil, fmt.Errorf("Could not fetch all teams from DB")
+	}
+
+	for _, v := range jt {
+		team := &Team{}
+
+		err = team.Unmarshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("Could not unmarshal team from DB.  Err: %v  JSON: %v", err, jt)
+		}
+
+		teams = append(teams, team)
+	}
+
+	return teams, nil
+}
+
+// Store a Team in the DB
+func (c *ChickenLittle) StoreTeam(t *Team) error {
+	jt, err := t.Marshal()
+	if err != nil {
+		return fmt.Errorf("Could not marshal team %+v", t)
+	}
+
+	err = c.DB.Store("teams", t.Name, string(jt))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete a Team from the DB
+func (c *ChickenLittle) DeleteTeam(t string) error {
+	err := c.DB.Delete("teams", t)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit adds an team API to manage teams (ordered lists of people).

This does not yet include any kind of notification or escalation
handling. I'm willing to provide an implementation for my proposal from #2 in an follow-up PR.
